### PR TITLE
Rebuild growth legend dashboard with timeframe controls

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1,1 +1,466 @@
-document.getElementById('root').innerText = 'Frontend is up!';
+import {
+  createInitialState,
+  createWidgetPayload,
+  escapeHtml,
+  getActiveSnapshot,
+  getFilteredMetrics,
+  renderCustomWidget,
+  renderFavoriteTile,
+  renderMetricCard,
+  setActiveTimeframe,
+  toggleFavorite
+} from './dashboard.js';
+
+const appState = createInitialState();
+
+function renderApp(state) {
+  const root = document.getElementById('root');
+  if (!root) return;
+
+  const snapshot = getActiveSnapshot(state);
+  const summary = snapshot.summary ?? { headline: '', subhead: '', tagline: '', cards: [] };
+  const metrics = Array.isArray(snapshot.metrics) ? snapshot.metrics : [];
+  const filteredMetrics = getFilteredMetrics(metrics, state.selectedCategory);
+  const favoriteMetrics = state.favoriteMetricIds
+    .map((id) => metrics.find((metric) => metric.id === id))
+    .filter(Boolean);
+  const hasHeroTrend = Array.isArray(snapshot.hero?.trend) && snapshot.hero.trend.length > 0;
+  const heroTrendMarkup = hasHeroTrend
+    ? `<div class="hero-spark">${renderHeroSpark(snapshot.hero.trend, state.timeframe)}</div>`
+    : '';
+  const heroChange = snapshot.hero?.change ?? '';
+  const heroDirection = heroChange.toString().trim().startsWith('-') ? 'down' : 'up';
+  const pipelineRows = Array.isArray(snapshot.pipeline) ? snapshot.pipeline : [];
+
+  root.innerHTML = `
+    <div class="app-shell">
+      <header class="top-bar">
+        <div class="brand">
+          <div class="brand-icon" aria-hidden="true">AX</div>
+          <div>
+            <h1>AgentX Growth Legend</h1>
+            <p>${escapeHtml(summary.tagline ?? '')}</p>
+          </div>
+        </div>
+        <div class="timeframe-toggle" role="group" aria-label="Select timeframe">
+          ${state.timeframeOptions
+            .map(
+              (option) => `
+                <button
+                  class="timeframe-btn"
+                  type="button"
+                  data-timeframe-id="${option.id}"
+                  aria-pressed="${state.timeframe === option.id}"
+                  title="${escapeHtml(option.description)}"
+                >
+                  ${escapeHtml(option.label)}
+                </button>
+              `
+            )
+            .join('')}
+        </div>
+        <div class="action-group">
+          <button class="action-btn" type="button" id="share-update">
+            <span aria-hidden="true">📊</span> Share investor update
+          </button>
+          <button class="action-btn primary" type="button" id="jump-to-widget">
+            <span aria-hidden="true">➕</span> Add dashboard widget
+          </button>
+        </div>
+      </header>
+
+      <section class="hero-grid">
+        <article class="hero-card">
+          <header>
+            <h2>${escapeHtml(summary.headline ?? '')}</h2>
+            <p>${escapeHtml(summary.subhead ?? '')}</p>
+          </header>
+          <div class="hero-card__balance">
+            <div>
+              <span>${escapeHtml(snapshot.hero.label ?? '')}</span>
+              <strong>${escapeHtml(snapshot.hero.value ?? '')}</strong>
+            </div>
+            <small data-direction="${heroDirection}">
+              ${escapeHtml(heroChange)}
+            </small>
+          </div>
+          ${heroTrendMarkup}
+        </article>
+        <article class="focus-banner" aria-label="Executive summary">
+          <div class="focus-banner__headline">
+            <span>Executive signal</span>
+            <strong>${escapeHtml(summary.headline ?? '')}</strong>
+            <p>${escapeHtml(summary.subhead ?? '')}</p>
+          </div>
+          <div class="focus-metrics">
+            ${summary.cards
+              .map(
+                (card) => `
+                  <article class="focus-card">
+                    <span>${escapeHtml(card.label)}</span>
+                    <strong>${escapeHtml(card.value)}</strong>
+                    <small>${escapeHtml(card.change)}</small>
+                  </article>
+                `
+              )
+              .join('')}
+          </div>
+        </article>
+      </section>
+
+      ${state.bannerMessage ? `<div class="app-banner" role="status">${escapeHtml(state.bannerMessage)}</div>` : ''}
+
+      <section class="favorite-dock" aria-labelledby="favorites-heading">
+        <div class="favorite-dock__header">
+          <h2 id="favorites-heading">Focus metrics</h2>
+          <p>Pin revenue, people, and efficiency KPIs to monitor like a trading legend.</p>
+        </div>
+        ${favoriteMetrics.length
+          ? `<div class="favorite-dock__grid">${favoriteMetrics
+              .map((metric) => renderFavoriteTile(metric))
+              .join('')}</div>`
+          : '<div class="empty-state">Select the star icon on any card to build your focus strip.</div>'}
+      </section>
+
+      <main class="layout">
+        <div class="column">
+          <section class="panel" id="metrics" aria-labelledby="metrics-heading">
+            <div class="panel__header">
+              <div>
+                <h2 id="metrics-heading">North star metrics</h2>
+                <p>All operating metrics visualized with Robinhood-style clarity.</p>
+              </div>
+              <div class="filter-chips" role="group" aria-label="Filter metrics by category">
+                ${['All', 'Revenue', 'Product', 'People', 'Efficiency']
+                  .map((category) => {
+                    const isActive = state.selectedCategory === category;
+                    return `
+                      <button class="filter-chip" type="button" data-category="${category}" aria-pressed="${isActive}">
+                        ${category}
+                      </button>
+                    `;
+                  })
+                  .join('')}
+              </div>
+            </div>
+            ${filteredMetrics.length
+              ? `<div class="metrics-grid">${filteredMetrics
+                  .map((metric) => renderMetricCard(metric, state.favoriteMetricIds.includes(metric.id)))
+                  .join('')}</div>`
+              : '<div class="empty-state">No metrics found for this filter yet.</div>'}
+          </section>
+
+          <section class="panel" id="pipeline" aria-labelledby="pipeline-heading">
+            <div class="panel__header">
+              <div>
+                <h2 id="pipeline-heading">Pipeline momentum</h2>
+                <p>Assess coverage, velocity, and ownership to forecast revenue confidence.</p>
+              </div>
+            </div>
+            <table class="pipeline-table">
+              <thead>
+                <tr>
+                  <th scope="col">Stage</th>
+                  <th scope="col">Weighted value</th>
+                  <th scope="col">Conversion</th>
+                  <th scope="col">Velocity</th>
+                  <th scope="col">Owner</th>
+                </tr>
+              </thead>
+              <tbody>
+                ${pipelineRows
+                  .map(
+                    (row) => `
+                      <tr>
+                        <th scope="row">${escapeHtml(row.stage)}</th>
+                        <td>${escapeHtml(row.value)}</td>
+                        <td>${escapeHtml(row.conversion)}</td>
+                        <td>${escapeHtml(row.velocity)}</td>
+                        <td>${escapeHtml(row.owner)}</td>
+                      </tr>
+                    `
+                  )
+                  .join('')}
+              </tbody>
+            </table>
+            <div class="initiative-list" role="list">
+              ${state.initiatives
+                .map(
+                  (item) => `
+                    <div class="initiative-card" role="listitem">
+                      <header>
+                        <h3>${escapeHtml(item.title)}</h3>
+                        <span class="badge">${escapeHtml(item.owner)}</span>
+                      </header>
+                      <p>${escapeHtml(item.detail)}</p>
+                    </div>
+                  `
+                )
+                .join('')}
+            </div>
+          </section>
+
+          <section class="panel" id="leads" aria-labelledby="leads-heading">
+            <div class="panel__header">
+              <div>
+                <h2 id="leads-heading">Priority leads</h2>
+                <p>High intent accounts driving near-term revenue impact.</p>
+              </div>
+            </div>
+            <div class="lead-list" role="list">
+              ${state.leads
+                .map((lead, index) => {
+                  const action = lead.contacted
+                    ? '<span class="badge badge--success">Contacted</span>'
+                    : `<button type="button" data-lead-index="${index}" class="lead-action">Log outreach</button>`;
+                  return `
+                    <article class="lead-card" role="listitem">
+                      <header>
+                        <div>
+                          <h3>${escapeHtml(lead.company)}</h3>
+                          <p>${escapeHtml(lead.source)}</p>
+                        </div>
+                        <span class="badge">${escapeHtml(lead.stage)}</span>
+                      </header>
+                      <div class="lead-card__meta">
+                        <span>${escapeHtml(lead.value)}</span>
+                        <span>Owner: ${escapeHtml(lead.owner)}</span>
+                      </div>
+                      ${action}
+                    </article>
+                  `;
+                })
+                .join('')}
+            </div>
+          </section>
+        </div>
+
+        <div class="column">
+          <section class="panel" id="people" aria-labelledby="people-heading">
+            <div class="panel__header">
+              <div>
+                <h2 id="people-heading">People impact</h2>
+                <p>Track headcount, morale, and talent outcomes in one glance.</p>
+              </div>
+            </div>
+            <div class="people-highlight-grid">
+              ${state.peopleHighlights
+                .map(
+                  (highlight) => `
+                    <article class="people-highlight">
+                      <span>${escapeHtml(highlight.label)}</span>
+                      <strong>${escapeHtml(highlight.value)}</strong>
+                      <small>${escapeHtml(highlight.change)}</small>
+                    </article>
+                  `
+                )
+                .join('')}
+            </div>
+            <div class="hire-list" role="list">
+              ${state.hires
+                .map(
+                  (hire) => `
+                    <article class="hire-card" role="listitem">
+                      <header>
+                        <div>
+                          <h3>${escapeHtml(hire.role)}</h3>
+                          <p>${escapeHtml(hire.team)}</p>
+                        </div>
+                        <span class="badge">${escapeHtml(hire.status)}</span>
+                      </header>
+                      <p>${escapeHtml(hire.impact)}</p>
+                      <footer>Start: ${escapeHtml(hire.startDate)}</footer>
+                    </article>
+                  `
+                )
+                .join('')}
+            </div>
+          </section>
+
+          <section class="panel" id="dashboard" aria-labelledby="dashboard-heading">
+            <div class="panel__header">
+              <div>
+                <h2 id="dashboard-heading">My dashboard</h2>
+                <p>Create a personal command center that mirrors your leadership scorecard.</p>
+              </div>
+            </div>
+            <form id="custom-widget-form" class="widget-form">
+              <label for="custom-widget-title">
+                Metric title
+                <input id="custom-widget-title" name="title" type="text" placeholder="e.g. Revenue per rep" required />
+              </label>
+              <label for="custom-widget-value">
+                Current value
+                <input id="custom-widget-value" name="value" type="text" placeholder="e.g. $86K" required />
+              </label>
+              <label for="custom-widget-change">
+                Momentum (optional)
+                <input id="custom-widget-change" name="change" type="text" placeholder="e.g. +12% vs last month" />
+              </label>
+              <label for="custom-widget-category">
+                Category
+                <select id="custom-widget-category" name="category">
+                  <option value="Revenue">Revenue</option>
+                  <option value="Product">Product</option>
+                  <option value="People">People</option>
+                  <option value="Efficiency">Efficiency</option>
+                  <option value="Impact">Impact</option>
+                </select>
+              </label>
+              <label for="custom-widget-note">
+                Narrative (optional)
+                <textarea id="custom-widget-note" name="note" placeholder="Context to share with stakeholders"></textarea>
+              </label>
+              <div class="form-actions">
+                <button class="action-btn primary" type="submit">Add metric tile</button>
+                <button class="action-btn" type="reset">Reset</button>
+              </div>
+              <div class="widget-feedback" id="widget-feedback">${escapeHtml(state.widgetFeedback)}</div>
+            </form>
+            ${state.customWidgets.length
+              ? `<div class="widget-grid">${state.customWidgets
+                  .map((widget) => renderCustomWidget(widget))
+                  .join('')}</div>`
+              : '<div class="empty-state">Design your investor-ready dashboard by adding tiles above.</div>'}
+          </section>
+        </div>
+      </main>
+
+      <footer class="footer">
+        <span>AgentX • Growth intelligence synced to boardroom outcomes.</span>
+        <span>Data refresh: ${new Date().toLocaleString([], { hour: '2-digit', minute: '2-digit' })}</span>
+      </footer>
+    </div>
+  `;
+
+  registerInteractions();
+}
+
+function renderHeroSpark(trend, timeframe) {
+  const width = 220;
+  const height = 88;
+  const max = Math.max(...trend);
+  const min = Math.min(...trend);
+  const diff = max - min || 1;
+  const step = trend.length > 1 ? width / (trend.length - 1) : width;
+
+  const points = trend.map((value, index) => {
+    const x = trend.length > 1 ? step * index : width / 2;
+    const y = height - ((value - min) / diff) * height;
+    return { x, y };
+  });
+
+  const first = points[0];
+  const last = points[points.length - 1];
+  const linePath = points
+    .map((point, index) => `${index === 0 ? 'M' : 'L'}${point.x.toFixed(2)} ${point.y.toFixed(2)}`)
+    .join(' ');
+  const areaPath = `M${first.x.toFixed(2)} ${height.toFixed(2)} ${points
+    .map((point) => `L${point.x.toFixed(2)} ${point.y.toFixed(2)}`)
+    .join(' ')} L${last.x.toFixed(2)} ${height.toFixed(2)} Z`;
+
+  return `
+    <svg viewBox="0 0 ${width} ${height}" preserveAspectRatio="none" class="hero-sparkline" aria-label="${escapeHtml(
+      timeframe
+    )} performance trend">
+      <defs>
+        <linearGradient id="hero-gradient-${escapeHtml(timeframe)}" x1="0%" y1="0%" x2="0%" y2="100%">
+          <stop offset="0%" stop-color="rgba(90,123,255,0.55)" />
+          <stop offset="100%" stop-color="rgba(90,123,255,0.05)" />
+        </linearGradient>
+      </defs>
+      <path d="${areaPath}" fill="url(#hero-gradient-${escapeHtml(timeframe)})" class="sparkline-area"></path>
+      <path d="${linePath}" class="sparkline-line"></path>
+      <circle cx="${last.x.toFixed(2)}" cy="${last.y.toFixed(2)}" r="4.2" class="sparkline-dot"></circle>
+    </svg>
+  `;
+}
+
+function registerInteractions() {
+  document.querySelectorAll('.filter-chip').forEach((chip) => {
+    chip.addEventListener('click', () => {
+      const category = chip.getAttribute('data-category');
+      if (!category) return;
+      if (appState.selectedCategory === category) {
+        appState.selectedCategory = 'All';
+      } else {
+        appState.selectedCategory = category;
+      }
+      renderApp(appState);
+    });
+  });
+
+  document.querySelectorAll('.favorite-toggle').forEach((button) => {
+    button.addEventListener('click', () => {
+      const metricId = button.getAttribute('data-metric-id');
+      toggleFavorite(appState, metricId);
+      renderApp(appState);
+    });
+  });
+
+  document.querySelectorAll('[data-timeframe-id]').forEach((button) => {
+    button.addEventListener('click', () => {
+      const timeframe = button.getAttribute('data-timeframe-id');
+      if (!timeframe) return;
+      if (setActiveTimeframe(appState, timeframe)) {
+        appState.bannerMessage = `${button.textContent.trim()} snapshot loaded.`;
+        renderApp(appState);
+      }
+    });
+  });
+
+  document.querySelectorAll('[data-lead-index]').forEach((button) => {
+    button.addEventListener('click', () => {
+      const index = Number(button.getAttribute('data-lead-index'));
+      if (Number.isNaN(index)) return;
+      appState.leads[index].contacted = true;
+      appState.bannerMessage = `${appState.leads[index].company} logged as contacted.`;
+      renderApp(appState);
+    });
+  });
+
+  const widgetForm = document.getElementById('custom-widget-form');
+  if (widgetForm) {
+    widgetForm.addEventListener('submit', (event) => {
+      event.preventDefault();
+      const formData = new FormData(widgetForm);
+      const title = formData.get('title')?.toString() ?? '';
+      const value = formData.get('value')?.toString() ?? '';
+      const change = formData.get('change')?.toString() ?? '';
+      const category = formData.get('category')?.toString() ?? 'Impact';
+      const note = formData.get('note')?.toString() ?? '';
+
+      try {
+        const widget = createWidgetPayload({ title, value, change, category, note });
+        appState.customWidgets.unshift(widget);
+        appState.widgetFeedback = `${title.trim()} added to your dashboard.`;
+        widgetForm.reset();
+      } catch (error) {
+        appState.widgetFeedback = 'Add a title and value to create a tile.';
+      }
+
+      renderApp(appState);
+    });
+  }
+
+  const shareButton = document.getElementById('share-update');
+  if (shareButton) {
+    shareButton.addEventListener('click', () => {
+      appState.bannerMessage = 'Investor snapshot exported to shared drive.';
+      renderApp(appState);
+    });
+  }
+
+  const jumpButton = document.getElementById('jump-to-widget');
+  if (jumpButton) {
+    jumpButton.addEventListener('click', () => {
+      const titleField = document.getElementById('custom-widget-title');
+      if (titleField) {
+        titleField.scrollIntoView({ behavior: 'smooth', block: 'center' });
+        window.setTimeout(() => titleField.focus(), 300);
+      }
+    });
+  }
+}
+
+renderApp(appState);

--- a/frontend/dashboard.js
+++ b/frontend/dashboard.js
@@ -1,0 +1,445 @@
+const TIMEFRAME_OPTIONS = [
+  { id: '7d', label: '7D', description: 'Weekly pulse' },
+  { id: '30d', label: '30D', description: 'Monthly momentum' },
+  { id: '90d', label: '90D', description: 'Quarter-to-date' }
+];
+
+const SUMMARY_VARIANTS = {
+  '7d': {
+    headline: 'Weekly growth momentum is compounding across revenue and hiring.',
+    tagline: 'Operate like a modern CRO: share the story behind revenue, people, and pipeline in minutes.',
+    subhead: 'Seven-day pulse distilled for board updates and executive standups.',
+    cards: [
+      { label: 'Revenue generated', value: '$410K', change: '+$38K WoW' },
+      { label: 'Deals added', value: '21', change: '13 enterprise leads' },
+      { label: 'People hired', value: '4', change: '2 strategic roles closed' },
+      { label: 'Expansions', value: '$88K', change: '+11% vs last week' }
+    ]
+  },
+  '30d': {
+    headline: 'Revenue, pipeline, and people momentum are accelerating.',
+    tagline: 'Orchestrate revenue, talent, and customer outcomes with investor-grade clarity.',
+    subhead: 'Track the KPIs powering the next funding milestone with narrative context.',
+    cards: [
+      { label: 'Revenue generated', value: '$5.1M ARR', change: '+48% YoY' },
+      { label: 'Weighted pipeline', value: '$4.2M', change: '61 deals in motion' },
+      { label: 'People hired', value: '9', change: '5 critical roles onboarding' },
+      { label: 'Net retention', value: '134%', change: '+4 pts vs plan' }
+    ]
+  },
+  '90d': {
+    headline: 'Quarter-to-date performance is beating revenue and efficiency targets.',
+    tagline: 'Bring the Robinhood-like clarity of a modern portfolio to your operating metrics.',
+    subhead: 'Quarterly legend showing compounding gains and capital efficiency.',
+    cards: [
+      { label: 'Revenue generated', value: '$14.9M ARR', change: '+52% QoQ' },
+      { label: 'Weighted pipeline', value: '$12.1M', change: '182 opportunities' },
+      { label: 'People hired', value: '18', change: 'Hiring plan 86% complete' },
+      { label: 'Gross margin', value: '78%', change: '+3 pts QoQ' }
+    ]
+  }
+};
+
+const HERO_VARIANTS = {
+  '7d': {
+    label: 'Active revenue balance',
+    value: '$910K',
+    change: '+6.4% WoW',
+    trend: [640, 662, 675, 688, 704, 721, 728]
+  },
+  '30d': {
+    label: 'Operating growth balance',
+    value: '$3.4M',
+    change: '+18.6% MoM',
+    trend: [2100, 2250, 2310, 2480, 2655, 2890, 3400]
+  },
+  '90d': {
+    label: 'Quarterly growth balance',
+    value: '$9.6M',
+    change: '+41% QoQ',
+    trend: [3200, 3520, 3780, 4150, 4580, 5060, 6120]
+  }
+};
+
+const METRIC_TEMPLATE = [
+  {
+    id: 'mrr',
+    label: 'Monthly Recurring Revenue',
+    category: 'Revenue',
+    target: 'Next milestone: $500K MRR by July.',
+    note: 'Runway at 18.4 months with current burn plan.'
+  },
+  {
+    id: 'arr',
+    label: 'Net New ARR',
+    category: 'Revenue',
+    target: 'Stretch goal: $180K net new per month.',
+    note: 'Enterprise expansion driving 68% of growth.'
+  },
+  {
+    id: 'activation',
+    label: 'Enterprise Activation',
+    category: 'Product',
+    target: 'Goal: 70% activation by May.',
+    note: 'Post-sale concierge improving day-7 actions.'
+  },
+  {
+    id: 'nrr',
+    label: 'Net Revenue Retention',
+    category: 'Revenue',
+    target: 'Hold above 130% through Q3.',
+    note: 'Churn steady at 1.8%; expansion plans landing.'
+  },
+  {
+    id: 'hires',
+    label: 'Critical Roles Filled',
+    category: 'People',
+    target: 'Finance lead signing offer this week.',
+    note: 'Hiring plan 82% complete for go-to-market.'
+  },
+  {
+    id: 'efficiency',
+    label: 'LTV to CAC',
+    category: 'Efficiency',
+    target: 'Maintain above 5x while scaling ads.',
+    note: 'CAC payback now 7.8 months.'
+  }
+];
+
+const METRIC_VARIANTS = {
+  '7d': {
+    mrr: { value: '$410K', change: '+3.1% WoW', trend: [362, 368, 374, 381, 392, 401, 410] },
+    arr: { value: '$58K', change: '+18% vs plan', trend: [34, 36, 40, 44, 48, 53, 58] },
+    activation: { value: '61%', change: '+4 pts', trend: [48, 49, 51, 54, 56, 59, 61] },
+    nrr: { value: '132%', change: '+3 pts', trend: [118, 119, 121, 123, 126, 129, 132] },
+    hires: { value: '4', change: '+2 this week', trend: [1, 1, 2, 2, 3, 4, 4] },
+    efficiency: { value: '5.3x', change: '+0.2x', trend: [4.7, 4.8, 4.9, 5.1, 5.2, 5.2, 5.3] }
+  },
+  '30d': {
+    mrr: { value: '$428K', change: '+12.4% MoM', trend: [320, 335, 348, 360, 385, 402, 428] },
+    arr: { value: '$146K', change: '+28% vs target', trend: [68, 72, 88, 102, 119, 134, 146] },
+    activation: { value: '63%', change: '+6 pts', trend: [44, 47, 51, 55, 58, 60, 63] },
+    nrr: { value: '134%', change: '+4 pts', trend: [118, 120, 122, 125, 128, 130, 134] },
+    hires: { value: '9', change: '+3 this month', trend: [1, 2, 2, 3, 4, 6, 9] },
+    efficiency: { value: '5.6x', change: '+0.4x', trend: [4.1, 4.3, 4.6, 4.8, 5.1, 5.3, 5.6] }
+  },
+  '90d': {
+    mrr: { value: '$452K', change: '+29% QoQ', trend: [285, 300, 328, 356, 382, 416, 452] },
+    arr: { value: '$402K', change: '+54% vs last quarter', trend: [120, 142, 188, 236, 278, 334, 402] },
+    activation: { value: '68%', change: '+11 pts', trend: [42, 46, 51, 55, 60, 64, 68] },
+    nrr: { value: '139%', change: '+7 pts', trend: [120, 122, 126, 129, 132, 135, 139] },
+    hires: { value: '18', change: '+7 this quarter', trend: [6, 8, 10, 11, 13, 15, 18] },
+    efficiency: { value: '5.9x', change: '+0.7x', trend: [4.2, 4.4, 4.9, 5.2, 5.4, 5.6, 5.9] }
+  }
+};
+
+const PIPELINE_VARIANTS = {
+  '7d': [
+    { stage: 'Qualified Pipeline', value: '$1.1M', conversion: '31% win rate', velocity: '12.8 day avg', owner: 'Growth Pod A' },
+    { stage: 'Negotiation', value: '$860K', conversion: '58% win rate', velocity: '9.1 day avg', owner: 'Enterprise Pod' },
+    { stage: 'Commit', value: '$540K', conversion: '84% win rate', velocity: '6.9 day avg', owner: 'Executive Sponsor' }
+  ],
+  '30d': [
+    { stage: 'Qualified Pipeline', value: '$1.7M', conversion: '34% win rate', velocity: '11.2 day avg', owner: 'Growth Pod A' },
+    { stage: 'Negotiation', value: '$1.3M', conversion: '62% win rate', velocity: '8.4 day avg', owner: 'Enterprise Pod' },
+    { stage: 'Commit', value: '$820K', conversion: '88% win rate', velocity: '6.1 day avg', owner: 'Executive Sponsor' }
+  ],
+  '90d': [
+    { stage: 'Qualified Pipeline', value: '$2.6M', conversion: '36% win rate', velocity: '10.6 day avg', owner: 'Growth Pod A' },
+    { stage: 'Negotiation', value: '$2.1M', conversion: '64% win rate', velocity: '8.1 day avg', owner: 'Enterprise Pod' },
+    { stage: 'Commit', value: '$1.6M', conversion: '89% win rate', velocity: '5.6 day avg', owner: 'Executive Sponsor' }
+  ]
+};
+
+const PEOPLE_HIGHLIGHTS = [
+  { label: 'Headcount', value: '68', change: '+11 QoQ' },
+  { label: 'Revenue / FTE', value: '$75K', change: '+12% YoY' },
+  { label: 'Engagement', value: '+46 eNPS', change: '+8 pts' }
+];
+
+const HIRES = [
+  {
+    role: 'Director of Growth Marketing',
+    impact: 'Orchestrating multi-touch campaigns to fill enterprise pipeline.',
+    status: 'Offer signed',
+    startDate: 'Apr 22',
+    team: 'Go-to-Market'
+  },
+  {
+    role: 'Staff Data Scientist',
+    impact: 'Deploying predictive scoring that lifted win rates by 9 pts.',
+    status: 'In onboarding',
+    startDate: 'Apr 8',
+    team: 'Product Intelligence'
+  },
+  {
+    role: 'People Ops Partner',
+    impact: 'Accelerating hiring cycle time and manager enablement.',
+    status: 'Final interviews',
+    startDate: 'Target May 6',
+    team: 'People'
+  }
+];
+
+const INITIATIVES = [
+  {
+    title: 'PLG activation sprint',
+    detail: 'Lifecycle squad launching usage-based nudges for self-serve pipeline.',
+    owner: 'Product Marketing'
+  },
+  {
+    title: 'Hiring pipeline automation',
+    detail: 'RevOps + People Ops automating top-of-funnel scorecards to cut time-to-hire.',
+    owner: 'People Ops'
+  },
+  {
+    title: 'Investor spotlight tour',
+    detail: 'Executive team preparing curated dashboards for partner briefings.',
+    owner: 'Leadership'
+  }
+];
+
+const LEADS = [
+  {
+    company: 'Helios Robotics',
+    value: '$280K ARR',
+    source: 'Warm intro – Series B partner',
+    owner: 'Dana',
+    stage: 'Demo booked',
+    contacted: false
+  },
+  {
+    company: 'Northwind Energy',
+    value: '$190K ARR',
+    source: 'Outbound – ABM campaign',
+    owner: 'Luis',
+    stage: 'Business case review',
+    contacted: false
+  },
+  {
+    company: 'Atlas Bio',
+    value: '$86K ARR',
+    source: 'Product qualified lead',
+    owner: 'Shreya',
+    stage: 'Legal redlines',
+    contacted: true
+  }
+];
+
+function deepClone(value) {
+  if (typeof structuredClone === 'function') {
+    return structuredClone(value);
+  }
+  return JSON.parse(JSON.stringify(value));
+}
+
+function buildMetrics(timeframe) {
+  const variants = METRIC_VARIANTS[timeframe] || {};
+  return METRIC_TEMPLATE.map((metric) => {
+    const variant = variants[metric.id] || {};
+    return {
+      ...metric,
+      value: variant.value ?? '',
+      change: variant.change ?? '',
+      trend: variant.trend ? [...variant.trend] : []
+    };
+  });
+}
+
+function buildSnapshots() {
+  return TIMEFRAME_OPTIONS.reduce((acc, option) => {
+    acc[option.id] = {
+      summary: deepClone(SUMMARY_VARIANTS[option.id]),
+      metrics: buildMetrics(option.id),
+      pipeline: deepClone(PIPELINE_VARIANTS[option.id]),
+      hero: deepClone(HERO_VARIANTS[option.id])
+    };
+    return acc;
+  }, {});
+}
+
+export function escapeHtml(value = '') {
+  return value
+    .toString()
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+export function getChangeDirection(change) {
+  if (!change) return 'up';
+  const trimmed = change.toString().trim();
+  return trimmed.startsWith('-') ? 'down' : 'up';
+}
+
+export function buildSparkline(trend = [], id) {
+  if (!trend.length || !id) {
+    return '';
+  }
+
+  const width = 120;
+  const height = 48;
+  const max = Math.max(...trend);
+  const min = Math.min(...trend);
+  const diff = max - min || 1;
+  const step = trend.length > 1 ? width / (trend.length - 1) : width;
+
+  const points = trend.map((value, index) => {
+    const x = trend.length > 1 ? step * index : width / 2;
+    const y = height - ((value - min) / diff) * height;
+    return { x, y };
+  });
+
+  const first = points[0];
+  const last = points[points.length - 1];
+  const linePath = points
+    .map((point, index) => `${index === 0 ? 'M' : 'L'}${point.x.toFixed(2)} ${point.y.toFixed(2)}`)
+    .join(' ');
+  const areaPath = `M${first.x.toFixed(2)} ${height.toFixed(2)} ${points
+    .map((point) => `L${point.x.toFixed(2)} ${point.y.toFixed(2)}`)
+    .join(' ')} L${last.x.toFixed(2)} ${height.toFixed(2)} Z`;
+
+  return `
+    <svg viewBox="0 0 ${width} ${height}" preserveAspectRatio="none" aria-hidden="true" class="sparkline">
+      <defs>
+        <linearGradient id="gradient-${escapeHtml(id)}" x1="0%" y1="0%" x2="0%" y2="100%">
+          <stop offset="0%" stop-color="rgba(81,255,231,0.45)" />
+          <stop offset="100%" stop-color="rgba(81,255,231,0.05)" />
+        </linearGradient>
+      </defs>
+      <path d="${areaPath}" fill="url(#gradient-${escapeHtml(id)})" class="sparkline-area"></path>
+      <path d="${linePath}" class="sparkline-line"></path>
+      <circle cx="${last.x.toFixed(2)}" cy="${last.y.toFixed(2)}" r="3.6" class="sparkline-dot"></circle>
+    </svg>
+  `;
+}
+
+export function renderMetricCard(metric, isFavorite = false) {
+  const direction = getChangeDirection(metric.change);
+  return `
+    <article class="metric-card" data-metric-id="${escapeHtml(metric.id)}">
+      <header class="metric-card__header">
+        <div>
+          <span class="metric-card__category">${escapeHtml(metric.category)}</span>
+          <h3>${escapeHtml(metric.label)}</h3>
+        </div>
+        <button class="favorite-toggle" type="button" data-metric-id="${escapeHtml(metric.id)}" aria-pressed="${isFavorite}">
+          <span class="favorite-toggle__icon" aria-hidden="true">${isFavorite ? '★' : '☆'}</span>
+          <span class="sr-only">${isFavorite ? 'Remove from focus metrics' : 'Add to focus metrics'}</span>
+        </button>
+      </header>
+      <div class="metric-card__body">
+        <strong>${escapeHtml(metric.value)}</strong>
+        <small data-direction="${direction}">${escapeHtml(metric.change)}</small>
+      </div>
+      ${buildSparkline(metric.trend, `${metric.id}-card`)}
+      <footer>
+        <span>${escapeHtml(metric.note)}</span>
+        <span class="metric-card__target">${escapeHtml(metric.target)}</span>
+      </footer>
+    </article>
+  `;
+}
+
+export function renderFavoriteTile(metric) {
+  const direction = getChangeDirection(metric.change);
+  return `
+    <article class="favorite-card" data-metric-id="${escapeHtml(metric.id)}">
+      <header>
+        <span>${escapeHtml(metric.category)}</span>
+        <button class="favorite-toggle" type="button" data-metric-id="${escapeHtml(metric.id)}" aria-pressed="true">
+          <span class="favorite-toggle__icon" aria-hidden="true">★</span>
+          <span class="sr-only">Remove ${escapeHtml(metric.label)} from focus metrics</span>
+        </button>
+      </header>
+      <strong>${escapeHtml(metric.value)}</strong>
+      <small data-direction="${direction}">${escapeHtml(metric.change)}</small>
+      ${buildSparkline(metric.trend, `${metric.id}-favorite`)}
+    </article>
+  `;
+}
+
+export function renderCustomWidget(widget) {
+  const direction = getChangeDirection(widget.change);
+  return `
+    <article class="widget-card">
+      <header>
+        <div>
+          <span class="widget-card__category">${escapeHtml(widget.category)}</span>
+          <h3>${escapeHtml(widget.title)}</h3>
+        </div>
+        ${widget.change
+          ? `<small data-direction="${direction}">${escapeHtml(widget.change)}</small>`
+          : ''}
+      </header>
+      <strong>${escapeHtml(widget.value)}</strong>
+      ${widget.note ? `<p>${escapeHtml(widget.note)}</p>` : ''}
+    </article>
+  `;
+}
+
+export function getFilteredMetrics(metrics = [], category = 'All') {
+  if (category === 'All') return metrics;
+  return metrics.filter((metric) => metric.category === category);
+}
+
+export function getActiveSnapshot(state) {
+  if (!state) return { summary: { cards: [] }, metrics: [], pipeline: [], hero: {} };
+  return state.snapshots[state.timeframe] || { summary: { cards: [] }, metrics: [], pipeline: [], hero: {} };
+}
+
+export function setActiveTimeframe(state, timeframeId) {
+  if (!state || !state.snapshots?.[timeframeId]) {
+    return false;
+  }
+  if (state.timeframe === timeframeId) {
+    return false;
+  }
+  state.timeframe = timeframeId;
+  return true;
+}
+
+export function toggleFavorite(state, metricId) {
+  if (!state || !metricId) return [];
+  const favorites = state.favoriteMetricIds || [];
+  const index = favorites.indexOf(metricId);
+  if (index > -1) {
+    favorites.splice(index, 1);
+  } else {
+    favorites.unshift(metricId);
+  }
+  state.favoriteMetricIds = Array.from(new Set(favorites)).slice(0, 4);
+  return state.favoriteMetricIds;
+}
+
+export function createWidgetPayload({ title, value, change = '', category = 'Impact', note = '' }) {
+  if (!title || !value) {
+    throw new Error('Title and value are required');
+  }
+  return {
+    title: escapeHtml(title.trim()),
+    value: escapeHtml(value.trim()),
+    change: change ? escapeHtml(change.trim()) : '',
+    category: escapeHtml(category.trim() || 'Impact'),
+    note: note ? escapeHtml(note.trim()) : ''
+  };
+}
+
+export function createInitialState() {
+  return {
+    timeframe: '30d',
+    timeframeOptions: deepClone(TIMEFRAME_OPTIONS),
+    selectedCategory: 'All',
+    snapshots: buildSnapshots(),
+    peopleHighlights: deepClone(PEOPLE_HIGHLIGHTS),
+    hires: deepClone(HIRES),
+    initiatives: deepClone(INITIATIVES),
+    leads: deepClone(LEADS),
+    favoriteMetricIds: ['mrr', 'nrr', 'activation'],
+    customWidgets: [],
+    widgetFeedback: '',
+    bannerMessage: ''
+  };
+}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,12 +1,832 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
-  <meta charset="UTF-8">
-  <title>Agentic Web App</title>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>AgentX Growth Legend</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link
+    href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700&display=swap"
+    rel="stylesheet"
+  />
+  <style>
+    :root {
+      color-scheme: dark;
+      font-family: 'Outfit', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      --bg-page: #050713;
+      --bg-panel: rgba(11, 16, 31, 0.78);
+      --bg-panel-strong: rgba(13, 22, 43, 0.88);
+      --border: rgba(255, 255, 255, 0.08);
+      --border-strong: rgba(90, 123, 255, 0.35);
+      --text-primary: #f6f7ff;
+      --text-secondary: rgba(226, 230, 255, 0.72);
+      --text-tertiary: rgba(226, 230, 255, 0.52);
+      --accent: #5a7bff;
+      --accent-soft: rgba(90, 123, 255, 0.12);
+      --success: #63f8a0;
+      --danger: #ff7d92;
+    }
+
+    * {
+      margin: 0;
+      padding: 0;
+      box-sizing: border-box;
+    }
+
+    body {
+      min-height: 100vh;
+      background:
+        radial-gradient(circle at 16% -10%, rgba(81, 255, 231, 0.18), transparent 45%),
+        radial-gradient(circle at 88% 2%, rgba(90, 123, 255, 0.22), transparent 40%),
+        var(--bg-page);
+      color: var(--text-primary);
+      padding: 28px clamp(16px, 4vw, 48px);
+    }
+
+    h1,
+    h2,
+    h3 {
+      font-weight: 600;
+      letter-spacing: 0.01em;
+    }
+
+    p {
+      color: var(--text-secondary);
+      line-height: 1.5;
+    }
+
+    button {
+      font: inherit;
+      color: inherit;
+      border: none;
+      background: none;
+      cursor: pointer;
+    }
+
+    button:focus-visible,
+    a:focus-visible,
+    input:focus-visible,
+    textarea:focus-visible,
+    select:focus-visible {
+      outline: 2px solid rgba(81, 255, 231, 0.55);
+      outline-offset: 2px;
+    }
+
+    .app-shell {
+      display: flex;
+      flex-direction: column;
+      gap: 28px;
+      max-width: 1280px;
+      margin: 0 auto 48px;
+    }
+
+    .top-bar {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 24px;
+      flex-wrap: wrap;
+    }
+
+    .brand {
+      display: flex;
+      align-items: center;
+      gap: 16px;
+    }
+
+    .brand-icon {
+      width: 60px;
+      height: 60px;
+      border-radius: 18px;
+      background: linear-gradient(135deg, rgba(87, 130, 255, 0.95), rgba(81, 255, 231, 0.95));
+      color: #01040d;
+      display: grid;
+      place-items: center;
+      font-weight: 700;
+      font-size: 1.35rem;
+      letter-spacing: 0.08em;
+      box-shadow: 0 20px 40px rgba(74, 117, 255, 0.2);
+    }
+
+    .brand h1 {
+      font-size: clamp(1.4rem, 2.6vw, 2rem);
+    }
+
+    .brand p {
+      font-size: 0.95rem;
+    }
+
+    .timeframe-toggle {
+      display: flex;
+      gap: 10px;
+      padding: 6px;
+      border-radius: 999px;
+      background: rgba(90, 123, 255, 0.08);
+      border: 1px solid rgba(90, 123, 255, 0.25);
+    }
+
+    .timeframe-btn {
+      padding: 8px 16px;
+      border-radius: 999px;
+      background: transparent;
+      color: var(--text-secondary);
+      font-size: 0.85rem;
+      transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease;
+    }
+
+    .timeframe-btn[aria-pressed='true'] {
+      background: linear-gradient(135deg, rgba(87, 130, 255, 0.92), rgba(81, 255, 231, 0.9));
+      color: #050713;
+      font-weight: 600;
+      transform: translateY(-1px);
+    }
+
+    .timeframe-btn:hover {
+      color: var(--text-primary);
+    }
+
+    .action-group {
+      display: flex;
+      gap: 12px;
+      flex-wrap: wrap;
+    }
+
+    .action-btn {
+      border: 1px solid var(--border);
+      border-radius: 14px;
+      background: linear-gradient(135deg, rgba(16, 23, 45, 0.9), rgba(16, 24, 51, 0.75));
+      color: var(--text-primary);
+      padding: 12px 18px;
+      font-size: 0.95rem;
+      display: inline-flex;
+      align-items: center;
+      gap: 10px;
+      transition: transform 0.2s ease, box-shadow 0.3s ease;
+    }
+
+    .action-btn.primary {
+      background: linear-gradient(135deg, rgba(87, 130, 255, 0.95), rgba(81, 255, 231, 0.95));
+      color: #050713;
+      font-weight: 600;
+      border-color: transparent;
+    }
+
+    .action-btn:hover,
+    .action-btn:focus-visible {
+      transform: translateY(-1px);
+      box-shadow: 0 16px 32px rgba(90, 123, 255, 0.25);
+    }
+
+    .hero-grid {
+      display: grid;
+      gap: 24px;
+      grid-template-columns: minmax(0, 1.05fr) minmax(0, 1fr);
+    }
+
+    @media (max-width: 1080px) {
+      .hero-grid {
+        grid-template-columns: 1fr;
+      }
+    }
+
+    .hero-card {
+      background: var(--bg-panel-strong);
+      border: 1px solid var(--border);
+      border-radius: 28px;
+      padding: clamp(20px, 3vw, 32px);
+      display: grid;
+      gap: 20px;
+      position: relative;
+      overflow: hidden;
+    }
+
+    .hero-card::after {
+      content: '';
+      position: absolute;
+      inset: 0;
+      background: linear-gradient(135deg, rgba(81, 255, 231, 0.12), transparent 55%);
+      pointer-events: none;
+    }
+
+    .hero-card header h2 {
+      font-size: clamp(1.4rem, 2.8vw, 2.2rem);
+      margin-bottom: 6px;
+    }
+
+    .hero-card__balance {
+      display: flex;
+      justify-content: space-between;
+      align-items: flex-end;
+      gap: 16px;
+      flex-wrap: wrap;
+      position: relative;
+      z-index: 1;
+    }
+
+    .hero-card__balance span {
+      color: var(--text-tertiary);
+      text-transform: uppercase;
+      letter-spacing: 0.12em;
+      font-size: 0.75rem;
+    }
+
+    .hero-card__balance strong {
+      font-size: clamp(2rem, 4vw, 2.8rem);
+      font-weight: 600;
+    }
+
+    .hero-card small[data-direction='up'] {
+      color: var(--success);
+    }
+
+    .hero-card small[data-direction='down'] {
+      color: var(--danger);
+    }
+
+    .hero-spark {
+      position: relative;
+      z-index: 1;
+    }
+
+    .hero-sparkline,
+    .sparkline {
+      width: 100%;
+      height: auto;
+    }
+
+    .sparkline-area {
+      fill-opacity: 0.4;
+    }
+
+    .sparkline-line {
+      fill: none;
+      stroke: rgba(81, 255, 231, 0.9);
+      stroke-width: 2;
+    }
+
+    .sparkline-dot {
+      fill: rgba(81, 255, 231, 0.95);
+      stroke: #050713;
+      stroke-width: 1;
+    }
+
+    .focus-banner {
+      display: grid;
+      gap: 18px;
+      padding: clamp(20px, 3vw, 30px);
+      background: linear-gradient(135deg, rgba(11, 19, 42, 0.95), rgba(12, 33, 58, 0.8));
+      border-radius: 26px;
+      border: 1px solid var(--border);
+      backdrop-filter: blur(18px);
+      box-shadow: 0 28px 40px rgba(5, 7, 19, 0.55);
+    }
+
+    .focus-banner__headline {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+    }
+
+    .focus-banner__headline span {
+      font-size: 0.78rem;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+      color: var(--text-tertiary);
+    }
+
+    .focus-banner__headline strong {
+      font-size: clamp(1.45rem, 3vw, 2.15rem);
+    }
+
+    .focus-metrics {
+      display: grid;
+      gap: 16px;
+      grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    }
+
+    .focus-card {
+      padding: 16px;
+      border-radius: 18px;
+      background: rgba(11, 19, 39, 0.88);
+      border: 1px solid var(--border);
+      display: grid;
+      gap: 8px;
+    }
+
+    .focus-card span {
+      font-size: 0.78rem;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: var(--text-tertiary);
+    }
+
+    .focus-card strong {
+      font-size: 1.25rem;
+    }
+
+    .focus-card small {
+      color: var(--success);
+      font-size: 0.85rem;
+    }
+
+    .app-banner {
+      border-radius: 14px;
+      border: 1px solid rgba(81, 255, 231, 0.35);
+      padding: 14px 18px;
+      background: rgba(81, 255, 231, 0.1);
+      color: var(--text-primary);
+      font-size: 0.92rem;
+    }
+
+    .favorite-dock {
+      background: var(--bg-panel);
+      border: 1px solid var(--border);
+      border-radius: 26px;
+      padding: clamp(20px, 3vw, 28px);
+      display: grid;
+      gap: 18px;
+    }
+
+    .favorite-dock__header h2 {
+      margin-bottom: 6px;
+    }
+
+    .favorite-dock__grid {
+      display: grid;
+      gap: 16px;
+      grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    }
+
+    .favorite-card {
+      background: rgba(12, 21, 40, 0.92);
+      border: 1px solid var(--border);
+      border-radius: 20px;
+      padding: 16px;
+      display: grid;
+      gap: 10px;
+    }
+
+    .favorite-card header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 12px;
+    }
+
+    .favorite-card header span {
+      font-size: 0.78rem;
+      letter-spacing: 0.1em;
+      text-transform: uppercase;
+      color: var(--text-tertiary);
+    }
+
+    .favorite-card strong {
+      font-size: 1.35rem;
+    }
+
+    small[data-direction='up'] {
+      color: var(--success);
+    }
+
+    small[data-direction='down'] {
+      color: var(--danger);
+    }
+
+    .favorite-toggle {
+      background: rgba(90, 123, 255, 0.15);
+      border: 1px solid rgba(90, 123, 255, 0.4);
+      border-radius: 999px;
+      width: 36px;
+      height: 36px;
+      display: grid;
+      place-items: center;
+      color: #ffd966;
+      transition: transform 0.2s ease, background 0.2s ease;
+    }
+
+    .favorite-toggle[aria-pressed='false'] {
+      color: rgba(255, 217, 102, 0.5);
+      background: rgba(90, 123, 255, 0.1);
+      border-color: rgba(90, 123, 255, 0.25);
+    }
+
+    .favorite-toggle[aria-pressed='true'] {
+      background: rgba(90, 123, 255, 0.22);
+      border-color: rgba(90, 123, 255, 0.55);
+    }
+
+    .favorite-toggle:hover {
+      transform: translateY(-1px) scale(1.03);
+      background: rgba(90, 123, 255, 0.3);
+    }
+
+    .layout {
+      display: grid;
+      gap: 24px;
+      grid-template-columns: minmax(0, 1.5fr) minmax(0, 1fr);
+    }
+
+    @media (max-width: 1080px) {
+      .layout {
+        grid-template-columns: 1fr;
+      }
+    }
+
+    .layout > .column {
+      display: grid;
+      gap: 24px;
+      align-content: start;
+    }
+
+    .panel {
+      background: var(--bg-panel);
+      border: 1px solid var(--border);
+      border-radius: 26px;
+      padding: clamp(20px, 3vw, 28px);
+      display: grid;
+      gap: 18px;
+      position: relative;
+      overflow: hidden;
+    }
+
+    .panel::before {
+      content: '';
+      position: absolute;
+      inset: 0;
+      background: radial-gradient(circle at top right, rgba(90, 123, 255, 0.12), transparent 55%);
+      opacity: 0.75;
+      pointer-events: none;
+    }
+
+    .panel > * {
+      position: relative;
+      z-index: 1;
+    }
+
+    .panel__header {
+      display: flex;
+      justify-content: space-between;
+      align-items: flex-start;
+      gap: 18px;
+      flex-wrap: wrap;
+    }
+
+    .filter-chips {
+      display: flex;
+      gap: 10px;
+      flex-wrap: wrap;
+    }
+
+    .filter-chip {
+      border-radius: 999px;
+      padding: 8px 16px;
+      border: 1px solid rgba(90, 123, 255, 0.2);
+      background: rgba(90, 123, 255, 0.08);
+      font-size: 0.85rem;
+      color: var(--text-secondary);
+      transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease;
+    }
+
+    .filter-chip[aria-pressed='true'] {
+      background: linear-gradient(135deg, rgba(87, 130, 255, 0.95), rgba(81, 255, 231, 0.95));
+      color: #050713;
+      font-weight: 600;
+      transform: translateY(-1px);
+    }
+
+    .metrics-grid {
+      display: grid;
+      gap: 18px;
+      grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+    }
+
+    .metric-card {
+      background: rgba(12, 21, 42, 0.92);
+      border: 1px solid rgba(255, 255, 255, 0.08);
+      border-radius: 22px;
+      padding: 18px;
+      display: grid;
+      gap: 14px;
+    }
+
+    .metric-card__header {
+      display: flex;
+      justify-content: space-between;
+      align-items: flex-start;
+      gap: 12px;
+    }
+
+    .metric-card__category {
+      font-size: 0.75rem;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+      color: var(--text-tertiary);
+    }
+
+    .metric-card__body {
+      display: flex;
+      justify-content: space-between;
+      align-items: baseline;
+      gap: 12px;
+      flex-wrap: wrap;
+    }
+
+    .metric-card__body strong {
+      font-size: 1.4rem;
+    }
+
+    .metric-card footer {
+      display: flex;
+      justify-content: space-between;
+      gap: 12px;
+      flex-wrap: wrap;
+      color: var(--text-secondary);
+      font-size: 0.85rem;
+    }
+
+    .metric-card__target {
+      color: var(--text-tertiary);
+    }
+
+    .pipeline-table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 0.92rem;
+      background: rgba(5, 9, 21, 0.55);
+      border-radius: 18px;
+      overflow: hidden;
+    }
+
+    .pipeline-table th,
+    .pipeline-table td {
+      padding: 12px 16px;
+      text-align: left;
+      border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+    }
+
+    .pipeline-table thead {
+      background: rgba(90, 123, 255, 0.12);
+      color: var(--text-secondary);
+      text-transform: uppercase;
+      letter-spacing: 0.1em;
+      font-size: 0.72rem;
+    }
+
+    .pipeline-table tbody tr:last-child td,
+    .pipeline-table tbody tr:last-child th {
+      border-bottom: none;
+    }
+
+    .initiative-list {
+      display: grid;
+      gap: 14px;
+    }
+
+    .initiative-card {
+      background: rgba(8, 13, 27, 0.82);
+      border: 1px solid var(--border);
+      border-radius: 16px;
+      padding: 14px 16px;
+      display: grid;
+      gap: 8px;
+    }
+
+    .initiative-card header {
+      display: flex;
+      justify-content: space-between;
+      align-items: flex-start;
+      gap: 12px;
+    }
+
+    .badge {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      padding: 4px 10px;
+      border-radius: 999px;
+      background: rgba(90, 123, 255, 0.18);
+      color: var(--text-primary);
+      font-size: 0.75rem;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
+
+    .badge--success {
+      background: rgba(81, 255, 231, 0.18);
+      color: var(--success);
+    }
+
+    .lead-list {
+      display: grid;
+      gap: 16px;
+    }
+
+    .lead-card {
+      background: rgba(8, 14, 28, 0.82);
+      border: 1px solid var(--border);
+      border-radius: 18px;
+      padding: 18px;
+      display: grid;
+      gap: 10px;
+    }
+
+    .lead-card header {
+      display: flex;
+      justify-content: space-between;
+      align-items: flex-start;
+      gap: 12px;
+    }
+
+    .lead-card__meta {
+      display: flex;
+      justify-content: space-between;
+      gap: 12px;
+      flex-wrap: wrap;
+      color: var(--text-secondary);
+      font-size: 0.9rem;
+    }
+
+    .lead-action {
+      align-self: flex-start;
+      padding: 10px 16px;
+      border-radius: 12px;
+      background: rgba(81, 255, 231, 0.12);
+      border: 1px solid rgba(81, 255, 231, 0.4);
+      color: var(--text-primary);
+      font-size: 0.9rem;
+      transition: transform 0.2s ease, background 0.2s ease;
+    }
+
+    .lead-action:hover,
+    .lead-action:focus-visible {
+      transform: translateY(-1px);
+      background: rgba(81, 255, 231, 0.22);
+    }
+
+    .people-highlight-grid {
+      display: grid;
+      gap: 14px;
+      grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    }
+
+    .people-highlight {
+      background: rgba(11, 18, 34, 0.9);
+      border: 1px solid var(--border);
+      border-radius: 18px;
+      padding: 16px;
+      display: grid;
+      gap: 8px;
+    }
+
+    .people-highlight span {
+      font-size: 0.78rem;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: var(--text-tertiary);
+    }
+
+    .people-highlight strong {
+      font-size: 1.3rem;
+    }
+
+    .people-highlight small {
+      color: var(--success);
+      font-size: 0.85rem;
+    }
+
+    .hire-list {
+      display: grid;
+      gap: 16px;
+    }
+
+    .hire-card {
+      background: rgba(7, 12, 24, 0.88);
+      border: 1px solid var(--border);
+      border-radius: 18px;
+      padding: 18px;
+      display: grid;
+      gap: 10px;
+    }
+
+    .hire-card header {
+      display: flex;
+      justify-content: space-between;
+      align-items: flex-start;
+      gap: 12px;
+    }
+
+    .hire-card footer {
+      font-size: 0.82rem;
+      color: var(--text-tertiary);
+    }
+
+    .widget-form {
+      display: grid;
+      gap: 14px;
+    }
+
+    label {
+      display: grid;
+      gap: 6px;
+      font-size: 0.85rem;
+      color: var(--text-secondary);
+    }
+
+    input,
+    textarea,
+    select {
+      background: rgba(6, 11, 24, 0.9);
+      border: 1px solid rgba(255, 255, 255, 0.12);
+      border-radius: 12px;
+      padding: 10px 12px;
+      color: var(--text-primary);
+      font: inherit;
+      transition: border 0.2s ease, box-shadow 0.2s ease;
+    }
+
+    textarea {
+      resize: vertical;
+      min-height: 96px;
+    }
+
+    input:focus,
+    textarea:focus,
+    select:focus {
+      border-color: rgba(81, 255, 231, 0.5);
+      box-shadow: 0 0 0 4px rgba(81, 255, 231, 0.18);
+    }
+
+    .form-actions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 10px;
+    }
+
+    .widget-feedback {
+      min-height: 1.2em;
+      font-size: 0.85rem;
+      color: var(--text-secondary);
+    }
+
+    .widget-grid {
+      display: grid;
+      gap: 16px;
+      grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    }
+
+    .widget-card {
+      background: rgba(9, 16, 32, 0.88);
+      border: 1px solid var(--border);
+      border-radius: 20px;
+      padding: 16px;
+      display: grid;
+      gap: 10px;
+    }
+
+    .widget-card__category {
+      font-size: 0.75rem;
+      letter-spacing: 0.1em;
+      text-transform: uppercase;
+      color: var(--text-tertiary);
+    }
+
+    .empty-state {
+      border-radius: 16px;
+      border: 1px dashed rgba(255, 255, 255, 0.18);
+      background: rgba(10, 14, 28, 0.6);
+      padding: 18px;
+      text-align: center;
+      color: var(--text-secondary);
+      font-size: 0.92rem;
+    }
+
+    .footer {
+      display: flex;
+      justify-content: space-between;
+      flex-wrap: wrap;
+      gap: 12px;
+      color: var(--text-tertiary);
+      font-size: 0.85rem;
+      border-top: 1px solid rgba(255, 255, 255, 0.08);
+      padding-top: 18px;
+    }
+
+    .sr-only {
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      padding: 0;
+      margin: -1px;
+      overflow: hidden;
+      clip: rect(0, 0, 0, 0);
+      white-space: nowrap;
+      border: 0;
+    }
+  </style>
 </head>
 <body>
-  <h1>Agentic Web App Frontend</h1>
-  <div id="root"></div>
-  <script src="app.js"></script>
+  <div id="root" aria-live="polite"></div>
+  <script src="app.js" type="module"></script>
 </body>
 </html>

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,0 +1,1767 @@
+{
+  "name": "frontend",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "frontend",
+      "version": "1.0.0",
+      "license": "ISC",
+      "devDependencies": {
+        "vitest": "^1.5.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jest/schemas": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.27.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.52.5.tgz",
+      "integrity": "sha512-8c1vW4ocv3UOMp9K+gToY5zL2XiiVw3k7f1ksf4yO1FlDFQ1C2u72iACFnSOceJFsWskc2WZNqeRhFRPzv+wtQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.52.5.tgz",
+      "integrity": "sha512-mQGfsIEFcu21mvqkEKKu2dYmtuSZOBMmAl5CFlPGLY94Vlcm+zWApK7F/eocsNzp8tKmbeBP8yXyAbx0XHsFNA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.52.5.tgz",
+      "integrity": "sha512-takF3CR71mCAGA+v794QUZ0b6ZSrgJkArC+gUiG6LB6TQty9T0Mqh3m2ImRBOxS2IeYBo4lKWIieSvnEk2OQWA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.52.5.tgz",
+      "integrity": "sha512-W901Pla8Ya95WpxDn//VF9K9u2JbocwV/v75TE0YIHNTbhqUTv9w4VuQ9MaWlNOkkEfFwkdNhXgcLqPSmHy0fA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.52.5.tgz",
+      "integrity": "sha512-QofO7i7JycsYOWxe0GFqhLmF6l1TqBswJMvICnRUjqCx8b47MTo46W8AoeQwiokAx3zVryVnxtBMcGcnX12LvA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.52.5.tgz",
+      "integrity": "sha512-jr21b/99ew8ujZubPo9skbrItHEIE50WdV86cdSoRkKtmWa+DDr6fu2c/xyRT0F/WazZpam6kk7IHBerSL7LDQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.52.5.tgz",
+      "integrity": "sha512-PsNAbcyv9CcecAUagQefwX8fQn9LQ4nZkpDboBOttmyffnInRy8R8dSg6hxxl2Re5QhHBf6FYIDhIj5v982ATQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.52.5.tgz",
+      "integrity": "sha512-Fw4tysRutyQc/wwkmcyoqFtJhh0u31K+Q6jYjeicsGJJ7bbEq8LwPWV/w0cnzOqR2m694/Af6hpFayLJZkG2VQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.52.5.tgz",
+      "integrity": "sha512-a+3wVnAYdQClOTlyapKmyI6BLPAFYs0JM8HRpgYZQO02rMR09ZcV9LbQB+NL6sljzG38869YqThrRnfPMCDtZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.52.5.tgz",
+      "integrity": "sha512-AvttBOMwO9Pcuuf7m9PkC1PUIKsfaAJ4AYhy944qeTJgQOqJYJ9oVl2nYgY7Rk0mkbsuOpCAYSs6wLYB2Xiw0Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.52.5.tgz",
+      "integrity": "sha512-DkDk8pmXQV2wVrF6oq5tONK6UHLz/XcEVow4JTTerdeV1uqPeHxwcg7aFsfnSm9L+OO8WJsWotKM2JJPMWrQtA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.52.5.tgz",
+      "integrity": "sha512-W/b9ZN/U9+hPQVvlGwjzi+Wy4xdoH2I8EjaCkMvzpI7wJUs8sWJ03Rq96jRnHkSrcHTpQe8h5Tg3ZzUPGauvAw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.52.5.tgz",
+      "integrity": "sha512-sjQLr9BW7R/ZiXnQiWPkErNfLMkkWIoCz7YMn27HldKsADEKa5WYdobaa1hmN6slu9oWQbB6/jFpJ+P2IkVrmw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.52.5.tgz",
+      "integrity": "sha512-hq3jU/kGyjXWTvAh2awn8oHroCbrPm8JqM7RUpKjalIRWWXE01CQOf/tUNWNHjmbMHg/hmNCwc/Pz3k1T/j/Lg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.52.5.tgz",
+      "integrity": "sha512-gn8kHOrku8D4NGHMK1Y7NA7INQTRdVOntt1OCYypZPRt6skGbddska44K8iocdpxHTMMNui5oH4elPH4QOLrFQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.52.5.tgz",
+      "integrity": "sha512-hXGLYpdhiNElzN770+H2nlx+jRog8TyynpTVzdlc6bndktjKWyZyiCsuDAlpd+j+W+WNqfcyAWz9HxxIGfZm1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.52.5.tgz",
+      "integrity": "sha512-arCGIcuNKjBoKAXD+y7XomR9gY6Mw7HnFBv5Rw7wQRvwYLR7gBAgV7Mb2QTyjXfTveBNFAtPt46/36vV9STLNg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.52.5.tgz",
+      "integrity": "sha512-QoFqB6+/9Rly/RiPjaomPLmR/13cgkIGfA40LHly9zcH1S0bN2HVFYk3a1eAyHQyjs3ZJYlXvIGtcCs5tko9Cw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.52.5.tgz",
+      "integrity": "sha512-w0cDWVR6MlTstla1cIfOGyl8+qb93FlAVutcor14Gf5Md5ap5ySfQ7R9S/NjNaMLSFdUnKGEasmVnu3lCMqB7w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.52.5.tgz",
+      "integrity": "sha512-Aufdpzp7DpOTULJCuvzqcItSGDH73pF3ko/f+ckJhxQyHtp67rHw3HMNxoIdDMUITJESNE6a8uh4Lo4SLouOUg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.52.5.tgz",
+      "integrity": "sha512-UGBUGPFp1vkj6p8wCRraqNhqwX/4kNQPS57BCFc8wYh0g94iVIW33wJtQAx3G7vrjjNtRaxiMUylM0ktp/TRSQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.52.5.tgz",
+      "integrity": "sha512-TAcgQh2sSkykPRWLrdyy2AiceMckNf5loITqXxFI5VuQjS5tSuw3WlwdN8qv8vzjLAUTvYaH/mVjSFpbkFbpTg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.27.8",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
+      "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/expect": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-1.6.1.tgz",
+      "integrity": "sha512-jXL+9+ZNIJKruofqXuuTClf44eSpcHlgj3CiuNihUF3Ioujtmc0zIa3UJOW5RjDK1YLBJZnWBlPuqhYycLioog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "1.6.1",
+        "@vitest/utils": "1.6.1",
+        "chai": "^4.3.10"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-1.6.1.tgz",
+      "integrity": "sha512-3nSnYXkVkf3mXFfE7vVyPmi3Sazhb/2cfZGGs0JRzFsPFvAMBEcrweV1V1GsrstdXeKCTXlJbvnQwGWgEIHmOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "1.6.1",
+        "p-limit": "^5.0.0",
+        "pathe": "^1.1.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-1.6.1.tgz",
+      "integrity": "sha512-WvidQuWAzU2p95u8GAKlRMqMyN1yOJkGHnx3M1PL9Raf7AQ1kwLKg04ADlCa3+OXUZE7BceOhVZiuWAbzCKcUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "magic-string": "^0.30.5",
+        "pathe": "^1.1.1",
+        "pretty-format": "^29.7.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-1.6.1.tgz",
+      "integrity": "sha512-MGcMmpGkZebsMZhbQKkAf9CX5zGvjkBTqf8Zx3ApYWXr3wG+QvEu2eXWfnIIWYSJExIp4V9FCKDEeygzkYrXMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^2.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-1.6.1.tgz",
+      "integrity": "sha512-jOrrUvXM4Av9ZWiG1EajNto0u96kWAhJ1LmPmJhXXQx/32MecEKd10pOLYgS2BQx1TgkGhloPU1ArDW2vvaY6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "diff-sequences": "^29.6.3",
+        "estree-walker": "^3.0.3",
+        "loupe": "^2.3.7",
+        "pretty-format": "^29.7.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.5.0.tgz",
+      "integrity": "sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.3",
+        "deep-eql": "^4.1.3",
+        "get-func-name": "^2.0.2",
+        "loupe": "^2.3.6",
+        "pathval": "^1.1.1",
+        "type-detect": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
+      "integrity": "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-func-name": "^2.0.2"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/confbox": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.4.tgz",
+      "integrity": "sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-detect": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/diff-sequences": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
+      "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/execa": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
+      "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^8.0.1",
+        "human-signals": "^5.0.0",
+        "is-stream": "^3.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^5.1.0",
+        "onetime": "^6.0.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.17"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-func-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
+      "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
+      "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/human-signals": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
+      "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16.17.0"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/local-pkg": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-0.5.1.tgz",
+      "integrity": "sha512-9rrA30MRRP3gBD3HTGnC6cDFpaE1kVDWxWgqWJUN0RvDNAo+Nz/9GxB+nHOH0ifbVFy0hSA1V6vFDvnx54lTEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mlly": "^1.7.3",
+        "pkg-types": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/loupe": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
+      "integrity": "sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-func-name": "^2.0.1"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mimic-fn": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mlly": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.0.tgz",
+      "integrity": "sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "pathe": "^2.0.3",
+        "pkg-types": "^1.3.1",
+        "ufo": "^1.6.1"
+      }
+    },
+    "node_modules/mlly/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/npm-run-path": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+      "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm-run-path/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+      "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-5.0.0.tgz",
+      "integrity": "sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
+      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/pkg-types": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
+      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.1.8",
+        "mlly": "^1.7.4",
+        "pathe": "^2.0.1"
+      }
+    },
+    "node_modules/pkg-types/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/rollup": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.52.5.tgz",
+      "integrity": "sha512-3GuObel8h7Kqdjt0gxkEzaifHTqLVW56Y/bjN7PSQtkKr0w3V/QYSdt6QWYtd7A1xUtYQigtdUfgj1RvWVtorw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.52.5",
+        "@rollup/rollup-android-arm64": "4.52.5",
+        "@rollup/rollup-darwin-arm64": "4.52.5",
+        "@rollup/rollup-darwin-x64": "4.52.5",
+        "@rollup/rollup-freebsd-arm64": "4.52.5",
+        "@rollup/rollup-freebsd-x64": "4.52.5",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.52.5",
+        "@rollup/rollup-linux-arm-musleabihf": "4.52.5",
+        "@rollup/rollup-linux-arm64-gnu": "4.52.5",
+        "@rollup/rollup-linux-arm64-musl": "4.52.5",
+        "@rollup/rollup-linux-loong64-gnu": "4.52.5",
+        "@rollup/rollup-linux-ppc64-gnu": "4.52.5",
+        "@rollup/rollup-linux-riscv64-gnu": "4.52.5",
+        "@rollup/rollup-linux-riscv64-musl": "4.52.5",
+        "@rollup/rollup-linux-s390x-gnu": "4.52.5",
+        "@rollup/rollup-linux-x64-gnu": "4.52.5",
+        "@rollup/rollup-linux-x64-musl": "4.52.5",
+        "@rollup/rollup-openharmony-arm64": "4.52.5",
+        "@rollup/rollup-win32-arm64-msvc": "4.52.5",
+        "@rollup/rollup-win32-ia32-msvc": "4.52.5",
+        "@rollup/rollup-win32-x64-gnu": "4.52.5",
+        "@rollup/rollup-win32-x64-msvc": "4.52.5",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-final-newline": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+      "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-literal": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-2.1.1.tgz",
+      "integrity": "sha512-631UJ6O00eNGfMiWG78ck80dfBab8X6IVFB51jZK5Icd7XAs60Z5y7QdSd/wGIklnWvRbUNloVzhOKKmutxQ6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinypool": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-0.8.4.tgz",
+      "integrity": "sha512-i11VH5gS6IFeLY3gMBQ00/MmLncVP7JLXOw1vlgkytLmJK7QnEr7NXf0LBdxfmNPAeyetukOk0bOYrJrFGjYJQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-2.2.1.tgz",
+      "integrity": "sha512-KYad6Vy5VDWV4GH3fjpseMQ/XU2BhIYP7Vzd0LG44qRWm/Yt2WCOTicFdvmgo6gWaqooMQCawTtILVQJupKu7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/type-detect": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
+      "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ufo": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.1.tgz",
+      "integrity": "sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-1.6.1.tgz",
+      "integrity": "sha512-YAXkfvGtuTzwWbDSACdJSg4A4DZiAqckWe90Zapc/sEX3XvHcw1NdurM/6od8J207tSDqNbSsgdCacBgvJKFuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.4",
+        "pathe": "^1.1.1",
+        "picocolors": "^1.0.0",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-1.6.1.tgz",
+      "integrity": "sha512-Ljb1cnSJSivGN0LqXd/zmDbWEM0RNNg2t1QW/XUhYl/qPqyu7CsqeWtqQXHVaJsecLPuDoak2oJcZN2QoRIOag==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "1.6.1",
+        "@vitest/runner": "1.6.1",
+        "@vitest/snapshot": "1.6.1",
+        "@vitest/spy": "1.6.1",
+        "@vitest/utils": "1.6.1",
+        "acorn-walk": "^8.3.2",
+        "chai": "^4.3.10",
+        "debug": "^4.3.4",
+        "execa": "^8.0.1",
+        "local-pkg": "^0.5.0",
+        "magic-string": "^0.30.5",
+        "pathe": "^1.1.1",
+        "picocolors": "^1.0.0",
+        "std-env": "^3.5.0",
+        "strip-literal": "^2.0.0",
+        "tinybench": "^2.5.1",
+        "tinypool": "^0.8.3",
+        "vite": "^5.0.0",
+        "vite-node": "1.6.1",
+        "why-is-node-running": "^2.2.2"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "1.6.1",
+        "@vitest/ui": "1.6.1",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.1.tgz",
+      "integrity": "sha512-AyeEbWOu/TAXdxlV9wmGcR0+yh2j3vYPGOECcIj2S7MkrLyC7ne+oye2BKTItt0ii2PHk4cDy+95+LshzbXnGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    }
+  }
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,10 +4,13 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "vitest run"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
-  "type": "commonjs"
+  "type": "module",
+  "devDependencies": {
+    "vitest": "^1.5.0"
+  }
 }

--- a/frontend/tests/ui.test.js
+++ b/frontend/tests/ui.test.js
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildSparkline,
+  createInitialState,
+  createWidgetPayload,
+  escapeHtml,
+  getActiveSnapshot,
+  getChangeDirection,
+  getFilteredMetrics,
+  setActiveTimeframe,
+  toggleFavorite
+} from '../dashboard.js';
+
+describe('dashboard utilities', () => {
+  it('escapes html content safely', () => {
+    expect(escapeHtml('<script>alert(1)</script>')).toBe('&lt;script&gt;alert(1)&lt;/script&gt;');
+  });
+
+  it('detects change direction', () => {
+    expect(getChangeDirection('-12%')).toBe('down');
+    expect(getChangeDirection('+5%')).toBe('up');
+    expect(getChangeDirection('')).toBe('up');
+  });
+
+  it('builds sparkline svg markup', () => {
+    const svg = buildSparkline([1, 3, 2, 5], 'test');
+    expect(svg).toContain('gradient-test');
+    expect(svg).toContain('<svg');
+  });
+
+  it('creates state with default snapshot', () => {
+    const state = createInitialState();
+    expect(state.timeframe).toBe('30d');
+    const snapshot = getActiveSnapshot(state);
+    expect(Array.isArray(snapshot.metrics)).toBe(true);
+    expect(snapshot.metrics.length).toBeGreaterThan(0);
+  });
+
+  it('toggles favorite metrics', () => {
+    const state = createInitialState();
+    toggleFavorite(state, 'arr');
+    expect(state.favoriteMetricIds.includes('arr')).toBe(true);
+    const countAfterAdd = state.favoriteMetricIds.length;
+    toggleFavorite(state, 'arr');
+    expect(state.favoriteMetricIds.includes('arr')).toBe(false);
+    expect(state.favoriteMetricIds.length).toBeLessThanOrEqual(countAfterAdd);
+  });
+
+  it('sets timeframe when valid', () => {
+    const state = createInitialState();
+    const changed = setActiveTimeframe(state, '7d');
+    expect(changed).toBe(true);
+    expect(state.timeframe).toBe('7d');
+    const unchanged = setActiveTimeframe(state, '7d');
+    expect(unchanged).toBe(false);
+    const invalid = setActiveTimeframe(state, '1y');
+    expect(invalid).toBe(false);
+  });
+
+  it('filters metrics by category', () => {
+    const state = createInitialState();
+    const snapshot = getActiveSnapshot(state);
+    const revenueMetrics = getFilteredMetrics(snapshot.metrics, 'Revenue');
+    expect(revenueMetrics.every((metric) => metric.category === 'Revenue')).toBe(true);
+  });
+
+  it('creates widget payload with sanitization', () => {
+    const widget = createWidgetPayload({
+      title: 'Growth <Velocity>',
+      value: '$123K',
+      change: '+12% vs plan',
+      category: 'Revenue',
+      note: 'Focus on <expansion>'
+    });
+    expect(widget.title).toBe('Growth &lt;Velocity&gt;');
+    expect(widget.note).toContain('&lt;');
+    expect(() => createWidgetPayload({ title: '', value: '' })).toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- rearchitect the growth dashboard state into timeframe-driven snapshots, hero balance metrics, and safe widget creation utilities
- redesign the Growth Legend UI shell with timeframe toggles, favorite metric strip, and refreshed pipeline, people, and custom widget panels
- add vitest-based UI utility tests and wire npm test into the project scripts

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690cfccb9d04832b96f331753a1c97a9)